### PR TITLE
Add crew departure & groomer agent fields

### DIFF
--- a/app.py
+++ b/app.py
@@ -125,6 +125,8 @@ with tab1:
 ⏰ *Tiempos:*
 *STD:* {display_data.get('std', '')}
 *ATD:* {display_data.get('atd', '')}
+*Salida de Tripulacion:* {display_data.get('crew_departure', '')}
+*Cantidad de Agentes Groomers:* {display_data.get('number_groomers_agents', '')}
 *Groomers In:* {display_data.get('groomers_in', '')}
 *Groomers Out:* {display_data.get('groomers_out', '')}
 *Crew at Gate:* {display_data.get('crew_at_gate', '')}

--- a/src/components/flight_form.py
+++ b/src/components/flight_form.py
@@ -123,12 +123,25 @@ def render_flight_form() -> Tuple[bool, Dict[str, Any]]:
         with col3:
             # Usar el STD predeterminado desde session_state
             std = st.text_input(
-                "STD (Salida Programada)", 
-                value=st.session_state.default_std, 
-                placeholder="HH:MM", 
+                "STD (Salida Programada)",
+                value=st.session_state.default_std,
+                placeholder="HH:MM",
                 key="std"
             )
             atd = st.text_input("ATD (Salida Real)", value="", placeholder="HH:MM", key="atd")
+            crew_departure = st.text_input(
+                "Salida de Tripulacion",
+                value="",
+                placeholder="HH:MM",
+                key="crew_departure"
+            )
+            groomers_agents_options = [str(i) for i in range(31)]
+            number_groomers_agents = st.selectbox(
+                "Cantidad de Agentes Groomers",
+                options=groomers_agents_options,
+                index=0,
+                key="number_groomers_agents"
+            )
             groomers_in = st.text_input("Groomers In", value="", placeholder="HH:MM", key="groomers_in")
             groomers_out = st.text_input("Groomers Out", value="", placeholder="HH:MM", key="groomers_out")
         with col4:
@@ -309,7 +322,8 @@ def render_flight_form() -> Tuple[bool, Dict[str, Any]]:
     if submitted:
         return process_form_data(
                 flight_date, origin, destination, flight_number,
-                std, atd, groomers_in, groomers_out, crew_at_gate,
+                std, atd, crew_departure, number_groomers_agents,
+                groomers_in, groomers_out, crew_at_gate,
                 ok_to_board, flight_secure, cierre_de_puerta, push_back,
                 total_pax, pax_c, pax_y, infants, customs_in, customs_out,
                 delay, gate, carrousel, delay_code,
@@ -322,7 +336,8 @@ def render_flight_form() -> Tuple[bool, Dict[str, Any]]:
 
 def process_form_data(
     flight_date, origin, destination, flight_number,
-    std, atd, groomers_in, groomers_out, crew_at_gate,
+    std, atd, crew_departure, number_groomers_agents,
+    groomers_in, groomers_out, crew_at_gate,
     ok_to_board, flight_secure, cierre_de_puerta, push_back,
     total_pax, pax_c, pax_y, infants, customs_in, customs_out,
     delay, gate, carrousel, delay_code,
@@ -360,6 +375,7 @@ def process_form_data(
     time_fields = {
         "STD": std,
         "ATD": atd,
+        "Salida de Tripulacion": crew_departure,
         "Groomers In": groomers_in,
         "Groomers Out": groomers_out,
         "Crew at Gate": crew_at_gate,
@@ -413,6 +429,8 @@ def process_form_data(
         "flight_number": flight_number,
         "std": format_time_for_database(normalized_times["STD"]),
         "atd": format_time_for_database(normalized_times["ATD"]),
+        "crew_departure": format_time_for_database(normalized_times["Salida de Tripulacion"]),
+        "number_groomers_agents": number_groomers_agents,
         "groomers_in": format_time_for_database(normalized_times["Groomers In"]),
         "groomers_out": format_time_for_database(normalized_times["Groomers Out"]),
         "crew_at_gate": format_time_for_database(normalized_times["Crew at Gate"]),

--- a/src/components/tabs/timeline_tab.py
+++ b/src/components/tabs/timeline_tab.py
@@ -283,6 +283,8 @@ def display_flight_details(flights):
                 st.write(f"👨‍✈️ **Crew at Gate:** {flight.get('crew_at_gate', 'N/A')}")
                 st.write(f"✅ **OK to Board:** {flight.get('ok_to_board', 'N/A')}")
             with col2:
+                st.write(f"⏰ **Salida Tripulación:** {flight.get('crew_departure', 'N/A')}")
+                st.write(f"👷 **Agentes Groomers:** {flight.get('number_groomers_agents', 'N/A')}")
                 st.write(f"🔒 **Flight Secure:** {flight.get('flight_secure', 'N/A')}")
                 st.write(f"🚪 **Cierre de Puerta:** {flight.get('cierre_de_puerta', 'N/A')}")
                 st.write(f"🚜 **Push Back:** {flight.get('push_back', 'N/A')}")
@@ -325,6 +327,7 @@ def display_flight_schedule(flight):
     time_fields = {
         "STD": flight.get('std'),
         "ATD": flight.get('atd'),
+        "Salida de Tripulación": flight.get('crew_departure'),
         "Groomers In": flight.get('groomers_in'),
         "Groomers Out": flight.get('groomers_out'),
         "Crew at Gate": flight.get('crew_at_gate'),
@@ -348,5 +351,4 @@ def display_flight_schedule(flight):
 
         time_data.append({"Evento": event, "Hora": formatted_time})
 
-    # Mostrar tabla de horarios
-    st.dataframe(time_data, hide_index=True)
+    # Mostrar tabla de horarios    st.dataframe(time_data, hide_index=True)


### PR DESCRIPTION
## Summary
- extend flight form with `crew_departure` and `number_groomers_agents`
- include the new fields when validating and sending data
- show the new data in the timeline views and in the WhatsApp report

## Testing
- `python -m py_compile src/components/flight_form.py src/components/tabs/timeline_tab.py app.py`

------
https://chatgpt.com/codex/tasks/task_e_686d84b8ac30832ba5274a5e0f19111e